### PR TITLE
Fix types for vendored files

### DIFF
--- a/.changeset/sixty-hotels-kick.md
+++ b/.changeset/sixty-hotels-kick.md
@@ -1,0 +1,6 @@
+---
+'@popeindustries/lit-element': patch
+'@popeindustries/lit-html': patch
+---
+
+Fix types for vendored packages

--- a/packages/lit-element/.gitignore
+++ b/packages/lit-element/.gitignore
@@ -1,3 +1,4 @@
+/decorators
 /vendor
 /*.js
 /*.d.ts

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -33,11 +33,17 @@
     "./decorators.js": {
       "types": "./decorators.d.ts",
       "development": "./src/vendor/decorators.js",
-      "default": "./vendor/decorators.js"
+      "default": "./decorators.js"
+    },
+    "./reactive-controller.js": {
+      "types": "./reactive-controller.d.ts",
+      "development": "./src/vendor/reactive-controller.js",
+      "default": "./reactive-controller.js"
     },
     "./decorators/*": {
+      "types": "./decorators/*",
       "development": "./src/vendor/decorators/*",
-      "default": "./vendor/decorators/*"
+      "default": "./decorators/*"
     }
   },
   "files": [

--- a/packages/lit-element/scripts/build.js
+++ b/packages/lit-element/scripts/build.js
@@ -3,23 +3,47 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { vendorBuild } from '../../../scripts/vendor-build.js';
 
-const RE_SKIP = /lit-element-renderer\.js|private-ssr-support/;
+const RE_SKIP_SRC_COPY = /lit-element-renderer\.js|private-ssr-support/;
+const RE_SKIP_VENDOR_COPY = /css-tag|lit-element|reactive-element/;
 
-vendorBuild(path.resolve('./src/vendor'), path.resolve('./vendor'), [
+const srcDir = path.resolve('./src');
+const vendorDest = path.resolve('./vendor');
+const vendorSrc = path.resolve('./src/vendor');
+
+if (!fs.existsSync(path.resolve('decorators'))) {
+  fs.mkdirSync(path.resolve('decorators'));
+}
+
+vendorBuild(vendorSrc, vendorDest, [
   path.resolve('./node_modules/@lit/reactive-element'),
   path.resolve('./node_modules/lit-element'),
 ]);
 
-const srcDir = path.resolve('./src');
-const destDir = path.resolve();
-
 // Copy some root src files
 for (const basename of fs.readdirSync(srcDir)) {
-  const filepath = path.join(srcDir, basename);
-  const ext = path.extname(basename);
+  const filepath = path.resolve(srcDir, basename);
 
-  if (!RE_SKIP.test(basename) && (ext === '.ts' || ext === '.js')) {
-    fs.copyFileSync(filepath, path.join(destDir, basename));
+  if (!RE_SKIP_SRC_COPY.test(basename) && (basename.endsWith('.js') || basename.endsWith('.d.ts'))) {
+    fs.copyFileSync(filepath, path.resolve(basename));
+  }
+}
+
+// Generate aliases for vendored files.
+// This could be done in package.json#exports, but TS isn't able to resolve aliases.
+for (const basename of fs.readdirSync(vendorSrc)) {
+  if (!RE_SKIP_VENDOR_COPY.test(basename)) {
+    if (basename.endsWith('.js') || basename.endsWith('.d.ts')) {
+      const moduleName = basename.replace(/\.js|\.d\.ts/, '.js');
+      fs.writeFileSync(path.resolve(basename), `export * from './vendor/${moduleName}';`);
+    }
+  }
+}
+for (const basename of fs.readdirSync(path.join(vendorSrc, 'decorators'))) {
+  if (!RE_SKIP_VENDOR_COPY.test(basename)) {
+    if (basename.endsWith('.js') || basename.endsWith('.d.ts')) {
+      const moduleName = basename.replace(/\.js|\.d\.ts/, '.js');
+      fs.writeFileSync(path.resolve('decorators', basename), `export * from '../vendor/decorators/${moduleName}';`);
+    }
   }
 }
 

--- a/packages/lit-html-server/package.json
+++ b/packages/lit-html-server/package.json
@@ -14,11 +14,19 @@
     "template render"
   ],
   "type": "module",
-  "types": "index.d.ts",
   "exports": {
     ".": {
       "types": "./lit-html-server.d.ts",
       "node": "./lit-html-server.js",
+      "default": "./lit-html-service-worker.js"
+    },
+    "./lit-html-server.js": {
+      "types": "./lit-html-server.d.ts",
+      "node": "./lit-html-server.js",
+      "default": "./lit-html-service-worker.js"
+    },
+    "./lit-html-service-worker.js": {
+      "types": "./lit-html-server.d.ts",
       "default": "./lit-html-service-worker.js"
     },
     "./dom-shim.js": "./dom-shim.js",

--- a/packages/lit-html/.gitignore
+++ b/packages/lit-html/.gitignore
@@ -1,3 +1,4 @@
+/directives
 /vendor
 /*.js
 /*.d.ts

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -27,17 +27,17 @@
     "./async-directive.js": {
       "types": "./async-directive.d.ts",
       "development": "./src/vendor/async-directive.js",
-      "default": "./vendor/async-directive.js"
+      "default": "./async-directive.js"
     },
     "./directive-helpers.js": {
       "types": "./directive-helpers.d.ts",
       "development": "./src/vendor/directive-helpers.js",
-      "default": "./vendor/directive-helpers.js"
+      "default": "./directive-helpers.js"
     },
     "./directive.js": {
       "types": "./directive.d.ts",
       "development": "./src/vendor/directive.js",
-      "default": "./vendor/directive.js"
+      "default": "./directive.js"
     },
     "./lazy-hydration-mixin.js": {
       "types": "./lazy-hydration-mixin.d.ts",
@@ -46,11 +46,12 @@
     "./static.js": {
       "types": "./static.d.ts",
       "development": "./src/vendor/static.js",
-      "default": "./vendor/static.js"
+      "default": "./static.js"
     },
     "./directives/*": {
+      "types": "./directives/*",
       "development": "./src/vendor/directives/*",
-      "default": "./vendor/directives/*"
+      "default": "./directives/*"
     }
   },
   "files": [

--- a/packages/lit-html/scripts/build.js
+++ b/packages/lit-html/scripts/build.js
@@ -3,20 +3,44 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { vendorBuild } from '../../../scripts/vendor-build.js';
 
-vendorBuild(path.resolve('./src/vendor'), path.resolve('./vendor'), [path.resolve('./node_modules/lit-html')]);
-
-const RE_SKIP = /index\.js|private-ssr-support/;
+const RE_SKIP_SRC_COPY = /index\.js|private-ssr-support/;
+const RE_SKIP_VENDOR_COPY = /lit-html|private-async-helpers/;
 
 const srcDir = path.resolve('./src');
-const destDir = path.resolve();
+const vendorDest = path.resolve('./vendor');
+const vendorSrc = path.resolve('./src/vendor');
+
+if (!fs.existsSync(path.resolve('directives'))) {
+  fs.mkdirSync(path.resolve('directives'));
+}
+
+vendorBuild(vendorSrc, vendorDest, [path.resolve('./node_modules/lit-html')]);
 
 // Copy some root src files
 for (const basename of fs.readdirSync(srcDir)) {
-  const filepath = path.join(srcDir, basename);
-  const ext = path.extname(basename);
+  const filepath = path.resolve(srcDir, basename);
 
-  if (!RE_SKIP.test(basename) && (ext === '.ts' || ext === '.js')) {
-    fs.copyFileSync(filepath, path.join(destDir, basename));
+  if (!RE_SKIP_SRC_COPY.test(basename) && (basename.endsWith('.js') || basename.endsWith('.d.ts'))) {
+    fs.copyFileSync(filepath, path.resolve(basename));
+  }
+}
+
+// Generate aliases for vendored files.
+// This could be done in package.json#exports, but TS isn't able to resolve aliases.
+for (const basename of fs.readdirSync(vendorSrc)) {
+  if (!RE_SKIP_VENDOR_COPY.test(basename)) {
+    if (basename.endsWith('.js') || basename.endsWith('.d.ts')) {
+      const moduleName = basename.replace(/\.js|\.d\.ts/, '.js');
+      fs.writeFileSync(path.resolve(basename), `export * from './vendor/${moduleName}';`);
+    }
+  }
+}
+for (const basename of fs.readdirSync(path.join(vendorSrc, 'directives'))) {
+  if (!RE_SKIP_VENDOR_COPY.test(basename)) {
+    if (basename.endsWith('.js') || basename.endsWith('.d.ts')) {
+      const moduleName = basename.replace(/\.js|\.d\.ts/, '.js');
+      fs.writeFileSync(path.resolve('directives', basename), `export * from '../vendor/directives/${moduleName}';`);
+    }
   }
 }
 

--- a/packages/lit/src/html-server.d.ts
+++ b/packages/lit/src/html-server.d.ts
@@ -1,1 +1,3 @@
-export * from '@popeindustries/lit-html-server';
+// `@popeindustries/lit-html-server` is preferred,
+// but TS isn't happy resolving the default export with `node` condition?
+export * from '@popeindustries/lit-html-server/lit-html-server.js';


### PR DESCRIPTION
It seems that TypeScript 4.8 isn't yet able to resolve aliased `package.json#exports` entries (Node/dvlp/esbuild are able to). This fix autogenerates alias files to ensure that TypeScript is able to resolve the modules correctly.

Fixes #10 