### PR TITLE
Lit HTML Server: Create key from array string

### DIFF
--- a/.changeset/plenty-years-yawn.md
+++ b/.changeset/plenty-years-yawn.md
@@ -1,0 +1,7 @@
+---
+"@popeindustries/lit-html-server": patch
+"@popeindustries/lit-html": patch
+"@popeindustries/lit": patch
+---
+
+Lit HTML Server: Prevent server template cache from growing endlessly by stringifying keys used in Map

--- a/packages/lit-html-server/src/internal/template-instance.js
+++ b/packages/lit-html-server/src/internal/template-instance.js
@@ -18,11 +18,12 @@ let id = 0;
  */
 export function getTemplateInstance(result) {
   const strings = result.strings;
-  let template = templateCache.get(strings);
+  const key = strings.toString();
+  let template = templateCache.get(key);
 
   if (template === undefined) {
     template = getTemplate(strings);
-    templateCache.set(strings, template);
+    templateCache.set(key, template);
   }
 
   return new TemplateInstance(template, result.values);


### PR DESCRIPTION
## Problem
The problem is that for every new request on the server we end up having different array objects for the same template literal. Since its a new object it has the same shape but is not the same reference. Therefore we do not find a value in the lookup map for the object, which in turn makes the cache grow forever until it crashes since map can't be garbage collected like WeakMaps. 

e.g.:
![Screenshot 2022-10-07 at 16 04 29](https://user-images.githubusercontent.com/155505/194572393-15165ea9-ae38-4012-bfc6-a89c2aac0b81.png)

Here both `x` and `y` arrays, contain the same literals but they are different objects and therefore have different id when looking up from the map cache ☝🏽, which is what happens on the server side we get a new array object for every request, for the same template literals that we lookup but since they are different objects the map will not be able to find an entry for them.

## Whats done
Since the result.string is an `Array` type, we therefore do `key = strings.toString()` and by default join all the values in the array by the `,` separator. 

## Example 
We modified the compiled code with the following e.g.:
```js
var templateCache = /* @__PURE__ */ new Map();
var templateCache2 = new Map();
var id = 0;
function getTemplateInstance(result) {
  const strings = result.strings;
  let template = templateCache.get(strings);
  if (template === void 0) {
    // 
    template = getTemplate(strings);
    templateCache.set(strings, template);
    templateCache2.set(strings.toString(), template);
  } else {
    console.log(`cached (templateCache.size: ${templateCache.size}) (templateCache2.size: ${templateCache2.size})`)
  }

  return new TemplateInstance3(template, result.values);
}
```

We got the following output:
![Screenshot 2022-10-07 at 15 28 53](https://user-images.githubusercontent.com/155505/194564999-ab9aed98-b684-48f7-9d75-663691aded74.png)

As you can see the `templateCache` grows until we crash.
However `templateCache2` were we use a string always has 9 elements which equals to the amount of templates we have on the server. 
