### PR TITLE
Fix bug in RE_CUSTOM_ELEMENT where only tagnames with one dash was supported

### DIFF
--- a/.changeset/kind-lemons-work.md
+++ b/.changeset/kind-lemons-work.md
@@ -1,0 +1,5 @@
+---
+'@popeindustries/lit-html-server': patch
+---
+
+Fix bug in RE_CUSTOM_ELEMENT only matching cd tag names with one dash, not multiple.

--- a/packages/lit-html-server/src/dom-shim.js
+++ b/packages/lit-html-server/src/dom-shim.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-const RE_VALID_CE_NAME = /^[a-z][a-z0-9._-]*-[a-z0-9._-]*$/;
+const RE_VALID_CE_NAME = /^[a-z][a-z0-9._\p{Emoji_Presentation}-]*-[a-z0-9._\p{Emoji_Presentation}-]*$/u;
 
 if (typeof globalThis.window === 'undefined') {
   class Element {

--- a/packages/lit-html-server/src/internal/template.js
+++ b/packages/lit-html-server/src/internal/template.js
@@ -22,7 +22,7 @@ const RE_ATTR =
   />|[ \t\n\f\r](?:(?<attributeName>[^\s"'>=/]+)(?:(?<spacesAndEquals>[ \t\n\f\r]*=[ \t\n\f\r]*)(?<quoteChar>["'])?)?|$)/g;
 const RE_COMMENT_END = /-->/g;
 const RE_COMMENT_ALT_END = />/g;
-const RE_CUSTOM_ELEMENT = /^[a-z][a-z0-9._\p{Emoji_Presentation}]*-[a-z0-9._\p{Emoji_Presentation}]*$/u;
+const RE_CUSTOM_ELEMENT = /^[a-z][a-z0-9._\p{Emoji_Presentation}-]*-[a-z0-9._\p{Emoji_Presentation}-]*$/u;
 const RE_SINGLE_QUOTED_ATTR_VALUE = /^(?<attributeValue>[^'\n\f\r]*)(?:(?<closingChar>')|$)/;
 const RE_DOUBLE_QUOTED_ATTR_VALUE = /^(?<attributeValue>[^"\n\f\r]*)(?:(?<closingChar>")|$)/;
 const RE_UNQUOTED_ATTR_VALUE = /^(?<attributeValue>[^'"=<>` \t\n\f\r]+)/;

--- a/packages/lit-html-server/test/template-test.js
+++ b/packages/lit-html-server/test/template-test.js
@@ -100,6 +100,16 @@ describe('Parse', () => {
       template: '<my-el a="text"></my-el>',
       result: '<my-el[CUSTOM-ELEMENT-OPEN]</my-el[CUSTOM-ELEMENT-CLOSE]>',
     },
+    {
+      title: 'custom element tag-name two dashes',
+      template: '<my-el-tag a="text"></my-el-tag>',
+      result: '<my-el-tag[CUSTOM-ELEMENT-OPEN]</my-el-tag[CUSTOM-ELEMENT-CLOSE]>',
+    },
+    {
+      title: 'custom element tag-name multiple dashes',
+      template: '<my-el-tag-test a="text"></my-el-tag-test>',
+      result: '<my-el-tag-test[CUSTOM-ELEMENT-OPEN]</my-el-tag-test[CUSTOM-ELEMENT-CLOSE]>',
+    },
   ];
 
   const only = tests.filter(({ only }) => only);


### PR DESCRIPTION
- Add test case for ce tagnames containing mre than one dash, and fix for bug
- add changeset

closes https://github.com/popeindustries/lit/issues/26