### PR TITLE
feat: include @types/trusted-types as peer dependency

### DIFF
--- a/.changeset/tricky-otters-peel.md
+++ b/.changeset/tricky-otters-peel.md
@@ -1,0 +1,6 @@
+---
+"@popeindustries/lit-html": patch
+"@popeindustries/lit": patch
+---
+
+feat: include @types/trusted-types as peer dependency

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -164,6 +164,9 @@
     "@types/trusted-types": "^2.0.2",
     "lit-html": "^2.6.1"
   },
+  "peerDependencies": {
+    "@types/trusted-types": "^2.0.2"
+  },
   "scripts": {
     "build": "node ./scripts/build.js"
   }


### PR DESCRIPTION
The `@types/trusted-types` should be included as a peer dependency, so the clients also install them or are suggested todo so.  

This will ensure that the typescript compilation does not complain on missing types such as TrustetHTML e.g. 👇🏽 
![Screenshot 2023-03-28 at 15 04 17](https://user-images.githubusercontent.com/155505/228245331-9e157465-bcbc-4abf-9025-3bdccefcda92.png)
![Screenshot 2023-03-28 at 15 04 25](https://user-images.githubusercontent.com/155505/228245363-e32f8842-5066-4ea6-b58e-68098f2d9409.png)

And would make its easier for the end consumer to infer why they get an error like the following if they have decided to skip the peer dependencies