### PR TITLE
chore: remove soure map urls

### DIFF
--- a/.changeset/wicked-pugs-join.md
+++ b/.changeset/wicked-pugs-join.md
@@ -1,0 +1,6 @@
+---
+'@popeindustries/lit-element': patch
+'@popeindustries/lit-html': patch
+---
+
+remove unnecessary sourceMappingURL

--- a/packages/lit-element/src/vendor/css-tag.d.ts
+++ b/packages/lit-element/src/vendor/css-tag.d.ts
@@ -64,4 +64,3 @@ export declare const css: (strings: TemplateStringsArray, ...values: (CSSResultG
  */
 export declare const adoptStyles: (renderRoot: ShadowRoot, styles: Array<CSSResultOrNative>) => void;
 export declare const getCompatibleStyle: (s: CSSResultOrNative) => CSSResultOrNative;
-//# sourceMappingURL=css-tag.d.ts.map

--- a/packages/lit-element/src/vendor/css-tag.js
+++ b/packages/lit-element/src/vendor/css-tag.js
@@ -129,4 +129,3 @@ export const getCompatibleStyle = supportsAdoptingStyleSheets ||
     (NODE_MODE && global.CSSStyleSheet === undefined)
     ? (s) => s
     : (s) => s instanceof CSSStyleSheet ? cssResultFromStyleSheet(s) : s;
-//# sourceMappingURL=css-tag.js.map

--- a/packages/lit-element/src/vendor/decorators.d.ts
+++ b/packages/lit-element/src/vendor/decorators.d.ts
@@ -13,4 +13,3 @@ export * from './decorators/query-all.js';
 export * from './decorators/query-async.js';
 export * from './decorators/query-assigned-elements.js';
 export * from './decorators/query-assigned-nodes.js';
-//# sourceMappingURL=decorators.d.ts.map

--- a/packages/lit-element/src/vendor/decorators.js
+++ b/packages/lit-element/src/vendor/decorators.js
@@ -19,4 +19,3 @@ export * from './decorators/query-all.js';
 export * from './decorators/query-async.js';
 export * from './decorators/query-assigned-elements.js';
 export * from './decorators/query-assigned-nodes.js';
-//# sourceMappingURL=decorators.js.map

--- a/packages/lit-element/src/vendor/decorators/base.d.ts
+++ b/packages/lit-element/src/vendor/decorators/base.d.ts
@@ -45,4 +45,3 @@ export declare const decorateProperty: ({ finisher, descriptor, }: {
     finisher?: ((ctor: typeof ReactiveElement, property: PropertyKey) => void) | null | undefined;
     descriptor?: ((property: PropertyKey) => PropertyDescriptor) | undefined;
 }) => (protoOrDescriptor: ReactiveElement | ClassElement, name?: PropertyKey) => void | any;
-//# sourceMappingURL=base.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/base.js
+++ b/packages/lit-element/src/vendor/decorators/base.js
@@ -62,4 +62,3 @@ export const decorateProperty = ({ finisher, descriptor, }) => (protoOrDescripto
         return info;
     }
 };
-//# sourceMappingURL=base.js.map

--- a/packages/lit-element/src/vendor/decorators/custom-element.d.ts
+++ b/packages/lit-element/src/vendor/decorators/custom-element.d.ts
@@ -24,4 +24,3 @@ declare type CustomElementClass = Omit<typeof HTMLElement, 'new'>;
  */
 export declare const customElement: (tagName: string) => (classOrDescriptor: CustomElementClass | ClassDescriptor) => any;
 export {};
-//# sourceMappingURL=custom-element.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/custom-element.js
+++ b/packages/lit-element/src/vendor/decorators/custom-element.js
@@ -41,4 +41,3 @@ const standardCustomElement = (tagName, descriptor) => {
 export const customElement = (tagName) => (classOrDescriptor) => typeof classOrDescriptor === 'function'
     ? legacyCustomElement(tagName, classOrDescriptor)
     : standardCustomElement(tagName, classOrDescriptor);
-//# sourceMappingURL=custom-element.js.map

--- a/packages/lit-element/src/vendor/decorators/event-options.d.ts
+++ b/packages/lit-element/src/vendor/decorators/event-options.d.ts
@@ -35,4 +35,3 @@ import { ReactiveElement } from '../reactive-element.js';
  * @category Decorator
  */
 export declare function eventOptions(options: AddEventListenerOptions): (protoOrDescriptor: ReactiveElement | import("./base.js").ClassElement, name?: PropertyKey | undefined) => any;
-//# sourceMappingURL=event-options.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/event-options.js
+++ b/packages/lit-element/src/vendor/decorators/event-options.js
@@ -43,4 +43,3 @@ export function eventOptions(options) {
         },
     });
 }
-//# sourceMappingURL=event-options.js.map

--- a/packages/lit-element/src/vendor/decorators/property.d.ts
+++ b/packages/lit-element/src/vendor/decorators/property.d.ts
@@ -38,4 +38,3 @@ import { ClassElement } from './base.js';
  * @ExportDecoratedItems
  */
 export declare function property(options?: PropertyDeclaration): (protoOrDescriptor: Object | ClassElement, name?: PropertyKey) => any;
-//# sourceMappingURL=property.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/property.js
+++ b/packages/lit-element/src/vendor/decorators/property.js
@@ -89,4 +89,3 @@ export function property(options) {
         ? legacyProperty(options, protoOrDescriptor, name)
         : standardProperty(options, protoOrDescriptor);
 }
-//# sourceMappingURL=property.js.map

--- a/packages/lit-element/src/vendor/decorators/query-all.d.ts
+++ b/packages/lit-element/src/vendor/decorators/query-all.d.ts
@@ -29,4 +29,3 @@ import { ReactiveElement } from '../reactive-element.js';
  * @category Decorator
  */
 export declare function queryAll(selector: string): (protoOrDescriptor: ReactiveElement | import("./base.js").ClassElement, name?: PropertyKey | undefined) => any;
-//# sourceMappingURL=query-all.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/query-all.js
+++ b/packages/lit-element/src/vendor/decorators/query-all.js
@@ -40,4 +40,3 @@ export function queryAll(selector) {
         }),
     });
 }
-//# sourceMappingURL=query-all.js.map

--- a/packages/lit-element/src/vendor/decorators/query-assigned-elements.d.ts
+++ b/packages/lit-element/src/vendor/decorators/query-assigned-elements.d.ts
@@ -47,4 +47,3 @@ export interface QueryAssignedElementsOptions extends QueryAssignedNodesOptions 
  * @category Decorator
  */
 export declare function queryAssignedElements(options?: QueryAssignedElementsOptions): (protoOrDescriptor: ReactiveElement | import("./base.js").ClassElement, name?: PropertyKey | undefined) => any;
-//# sourceMappingURL=query-assigned-elements.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/query-assigned-elements.js
+++ b/packages/lit-element/src/vendor/decorators/query-assigned-elements.js
@@ -69,4 +69,3 @@ export function queryAssignedElements(options) {
         }),
     });
 }
-//# sourceMappingURL=query-assigned-elements.js.map

--- a/packages/lit-element/src/vendor/decorators/query-assigned-nodes.d.ts
+++ b/packages/lit-element/src/vendor/decorators/query-assigned-nodes.d.ts
@@ -77,4 +77,3 @@ export declare function queryAssignedNodes(options?: QueryAssignedNodesOptions):
  */
 export declare function queryAssignedNodes(slotName?: string, flatten?: boolean, selector?: string): TSDecoratorReturnType;
 export {};
-//# sourceMappingURL=query-assigned-nodes.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/query-assigned-nodes.js
+++ b/packages/lit-element/src/vendor/decorators/query-assigned-nodes.js
@@ -44,4 +44,3 @@ export function queryAssignedNodes(slotOrOptions, flatten, selector) {
         }),
     });
 }
-//# sourceMappingURL=query-assigned-nodes.js.map

--- a/packages/lit-element/src/vendor/decorators/query-async.d.ts
+++ b/packages/lit-element/src/vendor/decorators/query-async.d.ts
@@ -37,4 +37,3 @@ import { ReactiveElement } from '../reactive-element.js';
  * @category Decorator
  */
 export declare function queryAsync(selector: string): (protoOrDescriptor: ReactiveElement | import("./base.js").ClassElement, name?: PropertyKey | undefined) => any;
-//# sourceMappingURL=query-async.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/query-async.js
+++ b/packages/lit-element/src/vendor/decorators/query-async.js
@@ -54,4 +54,3 @@ export function queryAsync(selector) {
         }),
     });
 }
-//# sourceMappingURL=query-async.js.map

--- a/packages/lit-element/src/vendor/decorators/query.d.ts
+++ b/packages/lit-element/src/vendor/decorators/query.d.ts
@@ -30,4 +30,3 @@ import { ReactiveElement } from '../reactive-element.js';
  * @category Decorator
  */
 export declare function query(selector: string, cache?: boolean): (protoOrDescriptor: ReactiveElement | import("./base.js").ClassElement, name?: PropertyKey | undefined) => any;
-//# sourceMappingURL=query.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/query.js
+++ b/packages/lit-element/src/vendor/decorators/query.js
@@ -54,4 +54,3 @@ export function query(selector, cache) {
         },
     });
 }
-//# sourceMappingURL=query.js.map

--- a/packages/lit-element/src/vendor/decorators/state.d.ts
+++ b/packages/lit-element/src/vendor/decorators/state.d.ts
@@ -22,4 +22,3 @@ export interface InternalPropertyDeclaration<Type = unknown> {
  * @category Decorator
  */
 export declare function state(options?: InternalPropertyDeclaration): (protoOrDescriptor: Object | import("./base.js").ClassElement, name?: PropertyKey | undefined) => any;
-//# sourceMappingURL=state.d.ts.map

--- a/packages/lit-element/src/vendor/decorators/state.js
+++ b/packages/lit-element/src/vendor/decorators/state.js
@@ -26,4 +26,3 @@ export function state(options) {
         state: true,
     });
 }
-//# sourceMappingURL=state.js.map

--- a/packages/lit-element/src/vendor/lit-element.d.ts
+++ b/packages/lit-element/src/vendor/lit-element.d.ts
@@ -180,4 +180,3 @@ export declare const _$LE: {
     _$attributeToProperty: (el: LitElement, name: string, value: string | null) => void;
     _$changedProperties: (el: LitElement) => any;
 };
-//# sourceMappingURL=lit-element.d.ts.map

--- a/packages/lit-element/src/vendor/lit-element.js
+++ b/packages/lit-element/src/vendor/lit-element.js
@@ -255,4 +255,3 @@ if (DEV_MODE && globalThis.litElementVersions.length > 1) {
     issueWarning('multiple-versions', `Multiple versions of Lit loaded. Loading multiple versions ` +
         `is not recommended.`);
 }
-//# sourceMappingURL=lit-element.js.map

--- a/packages/lit-element/src/vendor/reactive-controller.d.ts
+++ b/packages/lit-element/src/vendor/reactive-controller.d.ts
@@ -74,4 +74,3 @@ export interface ReactiveController {
      */
     hostUpdated?(): void;
 }
-//# sourceMappingURL=reactive-controller.d.ts.map

--- a/packages/lit-element/src/vendor/reactive-controller.js
+++ b/packages/lit-element/src/vendor/reactive-controller.js
@@ -4,4 +4,3 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 export {};
-//# sourceMappingURL=reactive-controller.js.map

--- a/packages/lit-element/src/vendor/reactive-element.d.ts
+++ b/packages/lit-element/src/vendor/reactive-element.d.ts
@@ -724,4 +724,3 @@ export declare abstract class ReactiveElement extends HTMLElement implements Rea
      */
     protected firstUpdated(_changedProperties: PropertyValues): void;
 }
-//# sourceMappingURL=reactive-element.d.ts.map

--- a/packages/lit-element/src/vendor/reactive-element.js
+++ b/packages/lit-element/src/vendor/reactive-element.js
@@ -1045,4 +1045,3 @@ if (DEV_MODE && global.reactiveElementVersions.length > 1) {
     issueWarning('multiple-versions', `Multiple versions of Lit loaded. Loading multiple versions ` +
         `is not recommended.`);
 }
-//# sourceMappingURL=reactive-element.js.map

--- a/packages/lit-html/src/vendor/async-directive.d.ts
+++ b/packages/lit-html/src/vendor/async-directive.d.ts
@@ -168,4 +168,3 @@ export declare abstract class AsyncDirective extends Directive {
     protected disconnected(): void;
     protected reconnected(): void;
 }
-//# sourceMappingURL=async-directive.d.ts.map

--- a/packages/lit-html/src/vendor/async-directive.js
+++ b/packages/lit-html/src/vendor/async-directive.js
@@ -243,4 +243,3 @@ export class AsyncDirective extends Directive {
     disconnected() { }
     reconnected() { }
 }
-//# sourceMappingURL=async-directive.js.map

--- a/packages/lit-html/src/vendor/directive-helpers.d.ts
+++ b/packages/lit-html/src/vendor/directive-helpers.d.ts
@@ -103,4 +103,3 @@ export declare const getCommittedValue: (part: import("./lit-html.js").ChildPart
 export declare const removePart: (part: import("./lit-html.js").ChildPart) => void;
 export declare const clearPart: (part: import("./lit-html.js").ChildPart) => void;
 export {};
-//# sourceMappingURL=directive-helpers.d.ts.map

--- a/packages/lit-html/src/vendor/directive-helpers.js
+++ b/packages/lit-html/src/vendor/directive-helpers.js
@@ -173,4 +173,3 @@ export const removePart = (part) => {
 export const clearPart = (part) => {
     part._$clear();
 };
-//# sourceMappingURL=directive-helpers.js.map

--- a/packages/lit-html/src/vendor/directive.d.ts
+++ b/packages/lit-html/src/vendor/directive.d.ts
@@ -63,4 +63,3 @@ export declare abstract class Directive implements Disconnectable {
     abstract render(...props: Array<unknown>): unknown;
     update(_part: Part, props: Array<unknown>): unknown;
 }
-//# sourceMappingURL=directive.d.ts.map

--- a/packages/lit-html/src/vendor/directive.js
+++ b/packages/lit-html/src/vendor/directive.js
@@ -45,4 +45,3 @@ export class Directive {
         return this.render(...props);
     }
 }
-//# sourceMappingURL=directive.js.map

--- a/packages/lit-html/src/vendor/directives/async-append.d.ts
+++ b/packages/lit-html/src/vendor/directives/async-append.d.ts
@@ -36,4 +36,3 @@ export declare const asyncAppend: (value: AsyncIterable<unknown>, _mapper?: ((v:
  * directive's return type.
  */
 export type { AsyncAppendDirective };
-//# sourceMappingURL=async-append.d.ts.map

--- a/packages/lit-html/src/vendor/directives/async-append.js
+++ b/packages/lit-html/src/vendor/directives/async-append.js
@@ -50,4 +50,3 @@ class AsyncAppendDirective extends AsyncReplaceDirective {
  *     value. Useful for generating templates for each item in the iterable.
  */
 export const asyncAppend = directive(AsyncAppendDirective);
-//# sourceMappingURL=async-append.js.map

--- a/packages/lit-html/src/vendor/directives/async-replace.d.ts
+++ b/packages/lit-html/src/vendor/directives/async-replace.d.ts
@@ -36,4 +36,3 @@ export declare class AsyncReplaceDirective extends AsyncDirective {
  */
 export declare const asyncReplace: (value: AsyncIterable<unknown>, _mapper?: Mapper<unknown> | undefined) => import("../directive.js").DirectiveResult<typeof AsyncReplaceDirective>;
 export {};
-//# sourceMappingURL=async-replace.d.ts.map

--- a/packages/lit-html/src/vendor/directives/async-replace.js
+++ b/packages/lit-html/src/vendor/directives/async-replace.js
@@ -97,4 +97,3 @@ export class AsyncReplaceDirective extends AsyncDirective {
  *     value. Useful for generating templates for each item in the iterable.
  */
 export const asyncReplace = directive(AsyncReplaceDirective);
-//# sourceMappingURL=async-replace.js.map

--- a/packages/lit-html/src/vendor/directives/cache.d.ts
+++ b/packages/lit-html/src/vendor/directives/cache.d.ts
@@ -32,4 +32,3 @@ export declare const cache: (v: unknown) => import("../directive.js").DirectiveR
  * directive's return type.
  */
 export type { CacheDirective };
-//# sourceMappingURL=cache.d.ts.map

--- a/packages/lit-html/src/vendor/directives/cache.js
+++ b/packages/lit-html/src/vendor/directives/cache.js
@@ -75,4 +75,3 @@ class CacheDirective extends Directive {
  * ```
  */
 export const cache = directive(CacheDirective);
-//# sourceMappingURL=cache.js.map

--- a/packages/lit-html/src/vendor/directives/choose.d.ts
+++ b/packages/lit-html/src/vendor/directives/choose.d.ts
@@ -29,4 +29,3 @@
  * ```
  */
 export declare const choose: <T, V>(value: T, cases: [T, () => V][], defaultCase?: (() => V) | undefined) => V | undefined;
-//# sourceMappingURL=choose.d.ts.map

--- a/packages/lit-html/src/vendor/directives/choose.js
+++ b/packages/lit-html/src/vendor/directives/choose.js
@@ -38,4 +38,3 @@ export const choose = (value, cases, defaultCase) => {
     }
     return defaultCase === null || defaultCase === void 0 ? void 0 : defaultCase();
 };
-//# sourceMappingURL=choose.js.map

--- a/packages/lit-html/src/vendor/directives/class-map.d.ts
+++ b/packages/lit-html/src/vendor/directives/class-map.d.ts
@@ -42,4 +42,3 @@ export declare const classMap: (classInfo: ClassInfo) => import("../directive.js
  * directive's return type.
  */
 export type { ClassMapDirective };
-//# sourceMappingURL=class-map.d.ts.map

--- a/packages/lit-html/src/vendor/directives/class-map.js
+++ b/packages/lit-html/src/vendor/directives/class-map.js
@@ -87,4 +87,3 @@ class ClassMapDirective extends Directive {
  * @param classInfo
  */
 export const classMap = directive(ClassMapDirective);
-//# sourceMappingURL=class-map.js.map

--- a/packages/lit-html/src/vendor/directives/guard.d.ts
+++ b/packages/lit-html/src/vendor/directives/guard.d.ts
@@ -57,4 +57,3 @@ export declare const guard: (_value: unknown, f: () => unknown) => import("../di
  * directive's return type.
  */
 export type { GuardDirective };
-//# sourceMappingURL=guard.d.ts.map

--- a/packages/lit-html/src/vendor/directives/guard.js
+++ b/packages/lit-html/src/vendor/directives/guard.js
@@ -77,4 +77,3 @@ class GuardDirective extends Directive {
  * @param f the template function
  */
 export const guard = directive(GuardDirective);
-//# sourceMappingURL=guard.js.map

--- a/packages/lit-html/src/vendor/directives/if-defined.d.ts
+++ b/packages/lit-html/src/vendor/directives/if-defined.d.ts
@@ -11,4 +11,3 @@ import { nothing } from '../lit-html.js';
  * For other part types, this directive is a no-op.
  */
 export declare const ifDefined: <T>(value: T) => typeof nothing | NonNullable<T>;
-//# sourceMappingURL=if-defined.d.ts.map

--- a/packages/lit-html/src/vendor/directives/if-defined.js
+++ b/packages/lit-html/src/vendor/directives/if-defined.js
@@ -11,4 +11,3 @@ import { nothing } from '../lit-html.js';
  * For other part types, this directive is a no-op.
  */
 export const ifDefined = (value) => value !== null && value !== void 0 ? value : nothing;
-//# sourceMappingURL=if-defined.js.map

--- a/packages/lit-html/src/vendor/directives/join.d.ts
+++ b/packages/lit-html/src/vendor/directives/join.d.ts
@@ -18,4 +18,3 @@
  */
 export declare function join<I, J>(items: Iterable<I> | undefined, joiner: (index: number) => J): Iterable<I | J>;
 export declare function join<I, J>(items: Iterable<I> | undefined, joiner: J): Iterable<I | J>;
-//# sourceMappingURL=join.d.ts.map

--- a/packages/lit-html/src/vendor/directives/join.js
+++ b/packages/lit-html/src/vendor/directives/join.js
@@ -16,4 +16,3 @@ export function* join(items, joiner) {
         }
     }
 }
-//# sourceMappingURL=join.js.map

--- a/packages/lit-html/src/vendor/directives/keyed.d.ts
+++ b/packages/lit-html/src/vendor/directives/keyed.d.ts
@@ -24,4 +24,3 @@ export declare const keyed: (k: unknown, v: unknown) => import("../directive.js"
  * directive's return type.
  */
 export type { Keyed };
-//# sourceMappingURL=keyed.d.ts.map

--- a/packages/lit-html/src/vendor/directives/keyed.js
+++ b/packages/lit-html/src/vendor/directives/keyed.js
@@ -36,4 +36,3 @@ class Keyed extends Directive {
  * animation techniques.
  */
 export const keyed = directive(Keyed);
-//# sourceMappingURL=keyed.js.map

--- a/packages/lit-html/src/vendor/directives/live.d.ts
+++ b/packages/lit-html/src/vendor/directives/live.d.ts
@@ -40,4 +40,3 @@ export declare const live: (value: unknown) => import("../directive.js").Directi
  * directive's return type.
  */
 export type { LiveDirective };
-//# sourceMappingURL=live.d.ts.map

--- a/packages/lit-html/src/vendor/directives/live.js
+++ b/packages/lit-html/src/vendor/directives/live.js
@@ -74,4 +74,3 @@ class LiveDirective extends Directive {
  * passed in, or the binding will update every render.
  */
 export const live = directive(LiveDirective);
-//# sourceMappingURL=live.js.map

--- a/packages/lit-html/src/vendor/directives/map.d.ts
+++ b/packages/lit-html/src/vendor/directives/map.d.ts
@@ -20,4 +20,3 @@
  * ```
  */
 export declare function map<T>(items: Iterable<T> | undefined, f: (value: T, index: number) => unknown): Generator<unknown, void, unknown>;
-//# sourceMappingURL=map.d.ts.map

--- a/packages/lit-html/src/vendor/directives/map.js
+++ b/packages/lit-html/src/vendor/directives/map.js
@@ -27,4 +27,3 @@ export function* map(items, f) {
         }
     }
 }
-//# sourceMappingURL=map.js.map

--- a/packages/lit-html/src/vendor/directives/private-async-helpers.d.ts
+++ b/packages/lit-html/src/vendor/directives/private-async-helpers.d.ts
@@ -55,4 +55,3 @@ export declare class Pauser {
      */
     resume(): void;
 }
-//# sourceMappingURL=private-async-helpers.d.ts.map

--- a/packages/lit-html/src/vendor/directives/private-async-helpers.js
+++ b/packages/lit-html/src/vendor/directives/private-async-helpers.js
@@ -82,4 +82,3 @@ export class Pauser {
         this._promise = this._resolve = undefined;
     }
 }
-//# sourceMappingURL=private-async-helpers.js.map

--- a/packages/lit-html/src/vendor/directives/range.d.ts
+++ b/packages/lit-html/src/vendor/directives/range.d.ts
@@ -21,4 +21,3 @@
  */
 export declare function range(end: number): Iterable<number>;
 export declare function range(start: number, end: number, step?: number): Iterable<number>;
-//# sourceMappingURL=range.d.ts.map

--- a/packages/lit-html/src/vendor/directives/range.js
+++ b/packages/lit-html/src/vendor/directives/range.js
@@ -10,4 +10,3 @@ export function* range(startOrEnd, end, step = 1) {
         yield i;
     }
 }
-//# sourceMappingURL=range.js.map

--- a/packages/lit-html/src/vendor/directives/ref.d.ts
+++ b/packages/lit-html/src/vendor/directives/ref.d.ts
@@ -63,4 +63,3 @@ export declare const ref: (_ref: RefOrCallback) => import("../directive.js").Dir
  * directive's return type.
  */
 export type { RefDirective };
-//# sourceMappingURL=ref.d.ts.map

--- a/packages/lit-html/src/vendor/directives/ref.js
+++ b/packages/lit-html/src/vendor/directives/ref.js
@@ -120,4 +120,3 @@ class RefDirective extends AsyncDirective {
  * ```
  */
 export const ref = directive(RefDirective);
-//# sourceMappingURL=ref.js.map

--- a/packages/lit-html/src/vendor/directives/repeat.d.ts
+++ b/packages/lit-html/src/vendor/directives/repeat.d.ts
@@ -61,4 +61,3 @@ export declare const repeat: RepeatDirectiveFn;
  * directive's return type.
  */
 export type { RepeatDirective };
-//# sourceMappingURL=repeat.d.ts.map

--- a/packages/lit-html/src/vendor/directives/repeat.js
+++ b/packages/lit-html/src/vendor/directives/repeat.js
@@ -411,4 +411,3 @@ class RepeatDirective extends Directive {
  * items to values, and DOM will be reused against potentially different items.
  */
 export const repeat = directive(RepeatDirective);
-//# sourceMappingURL=repeat.js.map

--- a/packages/lit-html/src/vendor/directives/style-map.d.ts
+++ b/packages/lit-html/src/vendor/directives/style-map.d.ts
@@ -45,4 +45,3 @@ export declare const styleMap: (styleInfo: Readonly<StyleInfo>) => import("../di
  * directive's return type.
  */
 export type { StyleMapDirective };
-//# sourceMappingURL=style-map.d.ts.map

--- a/packages/lit-html/src/vendor/directives/style-map.js
+++ b/packages/lit-html/src/vendor/directives/style-map.js
@@ -98,4 +98,3 @@ class StyleMapDirective extends Directive {
  * @see {@link https://lit.dev/docs/templates/directives/#stylemap styleMap code samples on Lit.dev}
  */
 export const styleMap = directive(StyleMapDirective);
-//# sourceMappingURL=style-map.js.map

--- a/packages/lit-html/src/vendor/directives/template-content.d.ts
+++ b/packages/lit-html/src/vendor/directives/template-content.d.ts
@@ -23,4 +23,3 @@ export declare const templateContent: (template: HTMLTemplateElement) => import(
  * directive's return type.
  */
 export type { TemplateContentDirective };
-//# sourceMappingURL=template-content.d.ts.map

--- a/packages/lit-html/src/vendor/directives/template-content.js
+++ b/packages/lit-html/src/vendor/directives/template-content.js
@@ -28,4 +28,3 @@ class TemplateContentDirective extends Directive {
  * could lead to cross-site-scripting vulnerabilities.
  */
 export const templateContent = directive(TemplateContentDirective);
-//# sourceMappingURL=template-content.js.map

--- a/packages/lit-html/src/vendor/directives/unsafe-html.d.ts
+++ b/packages/lit-html/src/vendor/directives/unsafe-html.d.ts
@@ -24,4 +24,3 @@ export declare class UnsafeHTMLDirective extends Directive {
  * vulnerabilities.
  */
 export declare const unsafeHTML: (value: string | typeof noChange | typeof nothing | null | undefined) => import("../directive.js").DirectiveResult<typeof UnsafeHTMLDirective>;
-//# sourceMappingURL=unsafe-html.d.ts.map

--- a/packages/lit-html/src/vendor/directives/unsafe-html.js
+++ b/packages/lit-html/src/vendor/directives/unsafe-html.js
@@ -58,4 +58,3 @@ UnsafeHTMLDirective.resultType = HTML_RESULT;
  * vulnerabilities.
  */
 export const unsafeHTML = directive(UnsafeHTMLDirective);
-//# sourceMappingURL=unsafe-html.js.map

--- a/packages/lit-html/src/vendor/directives/unsafe-svg.d.ts
+++ b/packages/lit-html/src/vendor/directives/unsafe-svg.d.ts
@@ -24,4 +24,3 @@ export declare const unsafeSVG: (value: string | typeof import("../lit-html.js")
  * directive's return type.
  */
 export type { UnsafeSVGDirective };
-//# sourceMappingURL=unsafe-svg.d.ts.map

--- a/packages/lit-html/src/vendor/directives/unsafe-svg.js
+++ b/packages/lit-html/src/vendor/directives/unsafe-svg.js
@@ -21,4 +21,3 @@ UnsafeSVGDirective.resultType = SVG_RESULT;
  * vulnerabilities.
  */
 export const unsafeSVG = directive(UnsafeSVGDirective);
-//# sourceMappingURL=unsafe-svg.js.map

--- a/packages/lit-html/src/vendor/directives/until.d.ts
+++ b/packages/lit-html/src/vendor/directives/until.d.ts
@@ -41,4 +41,3 @@ export declare const until: (...values: unknown[]) => import("../directive.js").
  * The type of the class that powers this directive. Necessary for naming the
  * directive's return type.
  */
-//# sourceMappingURL=until.d.ts.map

--- a/packages/lit-html/src/vendor/directives/until.js
+++ b/packages/lit-html/src/vendor/directives/until.js
@@ -121,4 +121,3 @@ export const until = directive(UntilDirective);
  * directive's return type.
  */
 // export type {UntilDirective};
-//# sourceMappingURL=until.js.map

--- a/packages/lit-html/src/vendor/directives/when.d.ts
+++ b/packages/lit-html/src/vendor/directives/when.d.ts
@@ -23,4 +23,3 @@
 export declare function when<T, F>(condition: true, trueCase: () => T, falseCase?: () => F): T;
 export declare function when<T, F = undefined>(condition: false, trueCase: () => T, falseCase?: () => F): F;
 export declare function when<T, F = undefined>(condition: unknown, trueCase: () => T, falseCase?: () => F): T | F;
-//# sourceMappingURL=when.d.ts.map

--- a/packages/lit-html/src/vendor/directives/when.js
+++ b/packages/lit-html/src/vendor/directives/when.js
@@ -6,4 +6,3 @@
 export function when(condition, trueCase, falseCase) {
     return condition ? trueCase() : falseCase === null || falseCase === void 0 ? void 0 : falseCase();
 }
-//# sourceMappingURL=when.js.map

--- a/packages/lit-html/src/vendor/lit-html.d.ts
+++ b/packages/lit-html/src/vendor/lit-html.d.ts
@@ -544,4 +544,3 @@ export declare const render: {
     createSanitizer: SanitizerFactory;
     _testOnlyClearSanitizerFactoryDoNotCallOrElse: () => void;
 };
-//# sourceMappingURL=lit-html.d.ts.map

--- a/packages/lit-html/src/vendor/lit-html.js
+++ b/packages/lit-html/src/vendor/lit-html.js
@@ -1475,4 +1475,3 @@ if (ENABLE_EXTRA_SECURITY_HOOKS) {
             _testOnlyClearSanitizerFactoryDoNotCallOrElse;
     }
 }
-//# sourceMappingURL=lit-html.js.map

--- a/packages/lit-html/src/vendor/static.d.ts
+++ b/packages/lit-html/src/vendor/static.d.ts
@@ -79,4 +79,3 @@ export declare const html: (strings: TemplateStringsArray, ...values: unknown[])
  */
 export declare const svg: (strings: TemplateStringsArray, ...values: unknown[]) => TemplateResult;
 export {};
-//# sourceMappingURL=static.d.ts.map

--- a/packages/lit-html/src/vendor/static.js
+++ b/packages/lit-html/src/vendor/static.js
@@ -136,4 +136,3 @@ export const html = withStatic(coreHtml);
  * Includes static value support from `lit-html/static.js`.
  */
 export const svg = withStatic(coreSvg);
-//# sourceMappingURL=static.js.map


### PR DESCRIPTION
What the title says ☝🏽 , i guess this is a mistake when updating copying lit html sources, since there are no actual source map files packages with the `@popeindusctries/lit` packages.

## What are we trying to avoid

We currently see this error from dvlp, when developing locally
<img width="1727" alt="Skjermbilde 2024-06-13 kl  00 01 26" src="https://github.com/popeindustries/lit/assets/155505/b8940f81-af45-4711-93b8-29fa87b98711">

Which this PR will fix.

## We have a temp fix

We added this to dvlp for the time being:
```ts
  onRequest(req, res) {
   ...

    // Ignore .js.map exceptions from @popeindustries/lit packages
    if (
      req.url?.includes('node_modules/@popeindustries/lit-') &&
      req.url?.endsWith('.js.map')
    ) {
      res.writeHead(200);
      res.end('');
      return true;
    }
  },
``