### PR TITLE
Improve hydration error message when unexpected `TemplateResult` was rendered to part

### DIFF
--- a/.changeset/pretty-lamps-count.md
+++ b/.changeset/pretty-lamps-count.md
@@ -1,0 +1,5 @@
+---
+'@popeindustries/lit-html': patch
+---
+
+Specifying which lit comment resulted in hydration error in hydration failed error message.

--- a/packages/lit-html/src/index.js
+++ b/packages/lit-html/src/index.js
@@ -149,9 +149,7 @@ export function render(value, container, options = {}) {
 
     // Clear all server rendered elements if we have found opening/closing comments
     if (openingComment !== null && closingComment !== null) {
-      console.error(
-        `Hydration failed at lit comment: "${openingComment.data}". Clearing nodes and performing clean render`,
-      );
+      console.error(`Hydration failed. Clearing nodes and performing clean render`);
       /** @type { Node | null } */
       let node = closingComment;
 

--- a/packages/lit-html/src/index.js
+++ b/packages/lit-html/src/index.js
@@ -149,7 +149,9 @@ export function render(value, container, options = {}) {
 
     // Clear all server rendered elements if we have found opening/closing comments
     if (openingComment !== null && closingComment !== null) {
-      console.error(`hydration failed. Clearing nodes and performing clean render`);
+      console.error(
+        `Hydration failed at lit comment: "${openingComment.data}". Clearing nodes and performing clean render`,
+      );
       /** @type { Node | null } */
       let node = closingComment;
 

--- a/packages/lit-html/src/index.js
+++ b/packages/lit-html/src/index.js
@@ -438,6 +438,6 @@ function consoleUnexpectedTemplateResultError(value) {
       ...styles,
     );
   } catch (_e) {
-    console.error('Had trouble logging unexpected TemplateResult error');
+    console.error('Had trouble logging unexpected TemplateResult error message');
   }
 }


### PR DESCRIPTION
Fixes https://github.com/popeindustries/lit/issues/35

Maybe this is a very bad and naive suggestion on how this should be implemented, but I wondered if what is suggested in this PR is good enough 🤓 

We are anyhow  in need in our app to be able to better locate which (child) node that resulted in the hydration error.

## What this PR includes
- [x] Adding a function `consoleUnexpectedTemplateResultError(...)` that prints the html element that caused hydration to fail, when it was due to an unexpected template result rendered to part.
- [x] A patch release of package `lit-html`

### PR changes explained
I debugged where the error was thrown and where the error was caught. 
It was not an obvious variable in either places that contained the information about which HTML element that caused it.
The current implementation was the best place I could find it 🤓 Maybe it is a bad suggestion.

## Before & After
Should not change functionality, since it is just a `console.error(...)` message that is changes.

### Before
<img width="686" alt="image" src="https://github.com/user-attachments/assets/cd43bb33-a731-4a6d-80eb-280d0235a0cb">


### After
<img width="896" alt="image" src="https://github.com/user-attachments/assets/7ba022f8-bcae-4773-9561-88a277143b6a">

