### PR TITLE
Add error message when hydration failed due to unexpected primitive rendered to part

### DIFF
--- a/.changeset/hot-jars-know.md
+++ b/.changeset/hot-jars-know.md
@@ -1,0 +1,5 @@
+---
+'@popeindustries/lit-html': patch
+---
+
+Adding error message when hydration failed due to unexpected primitive rendered to part

--- a/packages/lit-html/src/index.js
+++ b/packages/lit-html/src/index.js
@@ -242,6 +242,7 @@ function openChildPart(value, marker, stack, options) {
       /** @type { Array<ChildPart> } */ (getPartCommittedValue(state.part)).push(part);
     } else {
       // Primitive likely rendered on client when TemplateResult rendered on server.
+      consoleUnexpectedPrimitiveError(value, marker, options);
       throw Error('unexpected primitive rendered to part');
     }
   }
@@ -414,6 +415,28 @@ function isIterable(iterator) {
     iterator != null &&
     (Array.isArray(iterator) || typeof (/** @type { Iterable<unknown> } */ (iterator)[Symbol.iterator]) === 'function')
   );
+}
+
+/**
+ * Print an error message that shows what HTML element got
+ * unexpected primitive rendered to part, and thus failed to hydrate.
+ * @param { unknown } value
+ * @param { Comment } marker
+ * @param { RenderOptions } [options]
+ */
+function consoleUnexpectedPrimitiveError(value, marker, options) {
+  try {
+    console.error(
+      'The following element was an unexpected primitive rendered to part on the client:' + '\n\n' + 'Parent element:',
+      options?.host,
+      '\n\n' + 'Element rendered on server:',
+      marker.parentElement,
+      '\n\n' + 'Element rendered on client:',
+      value + '\n\n',
+    );
+  } catch (_e) {
+    console.error('Had trouble logging unexpected primitive error message');
+  }
 }
 
 /**


### PR DESCRIPTION
☝️ 

Sort of a follow-up on https://github.com/popeindustries/lit/pull/41

## Before
Error in console:
<img width="880" alt="image" src="https://github.com/user-attachments/assets/6d544a21-69d5-4125-bf66-0bc96d7eb153">


## After
Error in console: 
<img width="1078" alt="image" src="https://github.com/user-attachments/assets/b738f729-dbd3-4812-9a4e-7019469b8b45">

Hovering over the html of what is the parent element in the error message, shows in the GUI what element is the parent:
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/85a98708-9206-4791-b74c-fa8902c541a5">
